### PR TITLE
fix: export plugin function

### DIFF
--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -1,6 +1,7 @@
 // Плагин MeshCentral: добавляет вкладку "VPN .network" (только заглушка)
 
-module.exports.vpnviewer = function (parent) {
+// Export plugin function directly so MeshCentral can load it
+module.exports = function (parent) {
   const obj = {};
   obj.parent = parent;
 


### PR DESCRIPTION
## Summary
- export plugin function directly so MeshCentral can load VPN Viewer

## Testing
- `node -e "const p = require('./vpnviewer.js'); console.log(typeof p); if (typeof p === 'function') console.log('function export');"`
- `node --check vpnviewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad7b80a9f08331a82007185da12ca7