### PR TITLE
Fix agent plugin export

### DIFF
--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -1,7 +1,5 @@
-// modules_meshcore/vpnviewer.js — модуль для MeshAgent (как в ScriptTask: через pluginHandler.<name>)
+// modules_meshcore/vpnviewer.js — модуль для MeshAgent
 (function () {
-  try { if (typeof pluginHandler !== 'object') { pluginHandler = {}; } } catch (e) { return; }
-
   var fs = null; try { fs = require('fs'); } catch (e) {}
 
   function reply(parent, reqid, act, extra) {
@@ -10,58 +8,57 @@
     try { parent.send(JSON.stringify(m)); } catch (_) {}
   }
 
-  // Один общий объект, как у ScriptTask
-  pluginHandler.vpnviewer = {
-    // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
-    consoleaction: function (args /*array*/, parent, grandparent) {
-      if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
-      var sub = String(args[0]).toLowerCase();
+  // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
+  function consoleaction(args /*array*/, parent, grandparent) {
+    if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
+    var sub = String(args[0]).toLowerCase();
 
-      if (sub === 'ping') return 'pong';
+    if (sub === 'ping') return 'pong';
 
-      if (sub === 'read') {
-        var p = args[1] || '/etc/systemd/network/10-vpn_vpn.network';
-        if (!fs) return 'fs unavailable';
-        try { return fs.readFileSync(p, 'utf8'); } catch (e) { return 'ERROR: ' + String(e); }
-      }
-
-      if (sub === 'write') {
-        var p2 = args[1] || '/etc/systemd/network/10-vpn_vpn.network';
-        var data = args.slice(2).join(' ');
-        if (!fs) return 'fs unavailable';
-        try { fs.writeFileSync(p2, data, 'utf8'); return 'OK'; } catch (e) { return 'ERROR: ' + String(e); }
-      }
-
-      return 'unknown subcommand';
-    },
-
-    // Канал сервер→агент для UI (ping/readFile/writeFile)
-    serveraction: function (cmd, parent /*ws*/, grandparent) {
-      try {
-        if (!cmd || !parent) return;
-        var p = cmd.path || '/etc/systemd/network/10-vpn_vpn.network';
-        var rid = cmd.reqid;
-
-        if (cmd.pluginaction === 'ping') { reply(parent, rid, 'pong'); return; }
-
-        if (cmd.pluginaction === 'readFile') {
-          var txt = null, err = null;
-          try { if (!fs) throw new Error('fs unavailable'); txt = fs.readFileSync(p, 'utf8'); } catch (e) { err = String(e); }
-          reply(parent, rid, 'fileContent', { content: txt, error: err });
-          return;
-        }
-
-        if (cmd.pluginaction === 'writeFile') {
-          var ok = false, err2 = null;
-          try { if (!fs) throw new Error('fs unavailable'); fs.writeFileSync(p, String(cmd.content || ''), 'utf8'); ok = true; } catch (e) { err2 = String(e); }
-          reply(parent, rid, 'writeResult', { ok: ok, error: err2 });
-          return;
-        }
-
-        reply(parent, rid, 'error', { error: 'unknown action' });
-      } catch (e) {
-        reply(parent, (cmd && cmd.reqid) ? cmd.reqid : null, 'error', { error: String(e) });
-      }
+    if (sub === 'read') {
+      var p = args[1] || '/etc/systemd/network/10-vpn_vpn.network';
+      if (!fs) return 'fs unavailable';
+      try { return fs.readFileSync(p, 'utf8'); } catch (e) { return 'ERROR: ' + String(e); }
     }
-  };
+
+    if (sub === 'write') {
+      var p2 = args[1] || '/etc/systemd/network/10-vpn_vpn.network';
+      var data = args.slice(2).join(' ');
+      if (!fs) return 'fs unavailable';
+      try { fs.writeFileSync(p2, data, 'utf8'); return 'OK'; } catch (e) { return 'ERROR: ' + String(e); }
+    }
+
+    return 'unknown subcommand';
+  }
+
+  // Канал сервер→агент для UI (ping/readFile/writeFile)
+  function serveraction(cmd, parent /*ws*/, grandparent) {
+    try {
+      if (!cmd || !parent) return;
+      var p = cmd.path || '/etc/systemd/network/10-vpn_vpn.network';
+      var rid = cmd.reqid;
+
+      if (cmd.pluginaction === 'ping') { reply(parent, rid, 'pong'); return; }
+
+      if (cmd.pluginaction === 'readFile') {
+        var txt = null, err = null;
+        try { if (!fs) throw new Error('fs unavailable'); txt = fs.readFileSync(p, 'utf8'); } catch (e) { err = String(e); }
+        reply(parent, rid, 'fileContent', { content: txt, error: err });
+        return;
+      }
+
+      if (cmd.pluginaction === 'writeFile') {
+        var ok = false, err2 = null;
+        try { if (!fs) throw new Error('fs unavailable'); fs.writeFileSync(p, String(cmd.content || ''), 'utf8'); ok = true; } catch (e) { err2 = String(e); }
+        reply(parent, rid, 'writeResult', { ok: ok, error: err2 });
+        return;
+      }
+
+      reply(parent, rid, 'error', { error: 'unknown action' });
+    } catch (e) {
+      reply(parent, (cmd && cmd.reqid) ? cmd.reqid : null, 'error', { error: String(e) });
+    }
+  }
+
+  module.exports = { consoleaction: consoleaction, serveraction: serveraction };
 })();


### PR DESCRIPTION
## Summary
- Export vpnviewer agent module via `module.exports`
- Provide `consoleaction` and `serveraction` functions for MeshAgent

## Testing
- `node --check modules_meshcore/vpnviewer.js`
- `node --check vpnviewer.js`


------
https://chatgpt.com/codex/tasks/task_e_68aed1dff6cc8331ace34837ae9b12f8