### PR TITLE
Add ping subcommand to plugin console

### DIFF
--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -36,16 +36,14 @@ module.exports.vpnviewer = function (parent) {
     QA("pluginVpnViewer", '<iframe id="vpnviewerFrame" style="width:100%;height:720px;border:0;overflow:auto" src="' + src + '"></iframe>');
   };
 
-  obj.consoleaction = function (args, myparent, grandparent) {
-    if (args && args[0] && String(args[0]).toLowerCase() === 'ping') return 'vpnviewer server plugin: pong';
-    return 'vpnviewer server plugin: console ok';
-  };
-
-    // Позволяет команде "plugin vpnviewer ..." не падать
   obj.consoleaction = function (args /* array */, myparent, grandparent) {
+    if (Array.isArray(args) && args.length > 0) {
+      const sub = String(args[0]).toLowerCase();
+      if (sub === 'ping') return 'vpnviewer server plugin: pong';
+    }
     // Можно вернуть синхронную строку (сервер сразу выведет её в консоль)
     // Эта команда НЕ общается с агентом — используйте вкладку «Плагины» для реального пинга.
-    return "vpnviewer server plugin: console ok. Для проверки агента используйте вкладку «Плагины» → «Проверка модуля».";
+    return 'vpnviewer server plugin: console ok. Для проверки агента используйте вкладку «Плагины» → «Проверка модуля».';
   };
   
   // ---------- HTTP (страница + API) ----------


### PR DESCRIPTION
## Summary
- Support `ping` subcommand in vpnviewer server plugin console action

## Testing
- `node --check vpnviewer.js`
- `node --check modules_meshcore/vpnviewer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2666aebc8331a541b88c8405a5e0