### PR TITLE
Expose console ping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # meshcentral-plugin-vpnviewer
-ggg
+
+MeshCentral plugin that adds a simple VPN network configuration viewer/editor.
+
+## Console test
+
+To verify that the server-side plugin is running, use the MeshCentral server console:
+
+```
+> plugin vpnviewer ping
+vpnviewer server plugin: pong
+```

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "name": "VPN Viewer",
   "shortName": "vpnviewer",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "author": "BAlekssei",
   "description": "Test plugin: adds VPN .network tab",
   "hasAdminPanel": false,

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -27,7 +27,7 @@ module.exports.vpnviewer = function (parent) {
   }
 
   // ---------- WebUI ----------
-  obj.exports = [ "onDeviceRefreshEnd" ];
+  obj.exports = [ "onDeviceRefreshEnd", "consoleaction" ];
   obj.onDeviceRefreshEnd = function () {
     pluginHandler.registerPluginTab({ tabTitle: "Плагины", tabId: "pluginVpnViewer" });
     let nodeId = "";


### PR DESCRIPTION
## Summary
- export `consoleaction` so the server plugin recognizes `plugin vpnviewer ping`
- document console ping usage in README
- bump plugin version to 0.0.60

## Testing
- `node -e "require('./vpnviewer.js'); console.log('vpnviewer loaded');"`
- `node -e "require('./modules_meshcore/vpnviewer.js'); console.log('agent module loaded');"`
- `node - <<'NODE'
const p = require('./vpnviewer.js').vpnviewer({parent:{}});
console.log(p.exports);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68af281a899c83318ffc68a55d513ac8