### PR TITLE
Fix ping console command

### DIFF
--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -11,7 +11,8 @@
   // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
   function consoleaction(args /*array*/, parent, grandparent) {
     if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
-    var sub = String(args[0]).toLowerCase();
+    if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
+    var sub = String((args[0] || '')).toLowerCase();
 
     if (sub === 'ping') return 'pong';
 

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -38,7 +38,8 @@ module.exports.vpnviewer = function (parent) {
 
   obj.consoleaction = function (args /* array */, myparent, grandparent) {
     if (Array.isArray(args) && args.length > 0) {
-      const sub = String(args[0]).toLowerCase();
+      if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
+      const sub = String((args[0] || '')).toLowerCase();
       if (sub === 'ping') return 'vpnviewer server plugin: pong';
     }
     // Можно вернуть синхронную строку (сервер сразу выведет её в консоль)


### PR DESCRIPTION
## Summary
- handle vpnviewer prefix in plugin console arguments
- allow agent and server modules to respond to `plugin vpnviewer ping`

## Testing
- `node -e "const p=require('./vpnviewer.js').vpnviewer({parent:{}}); console.log('test1',p.consoleaction(['vpnviewer','ping'])); console.log('test2',p.consoleaction(['ping']));"`
- `node -e "const m=require('./modules_meshcore/vpnviewer.js'); console.log('test1',m.consoleaction(['vpnviewer','ping'])); console.log('test2',m.consoleaction(['ping'])); console.log('unknown',m.consoleaction(['vpnviewer','foo']));"`


------
https://chatgpt.com/codex/tasks/task_e_68af2b69b3a88331b778a5cd596df18b