### PR TITLE
Handle string args in VPN Viewer plugin console

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "name": "VPN Viewer",
   "shortName": "vpnviewer",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "author": "BAlekssei",
   "description": "Test plugin: adds VPN .network tab",
   "hasAdminPanel": false,

--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -9,7 +9,8 @@
   }
 
   // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
-  function consoleaction(args /*array*/, parent, grandparent) {
+  function consoleaction(args /*array|string*/, parent, grandparent) {
+    if (typeof args === 'string') args = args.split(' ');
     if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
     if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
     var sub = String((args[0] || '')).toLowerCase();

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -36,7 +36,8 @@ module.exports.vpnviewer = function (parent) {
     QA("pluginVpnViewer", '<iframe id="vpnviewerFrame" style="width:100%;height:720px;border:0;overflow:auto" src="' + src + '"></iframe>');
   };
 
-  obj.consoleaction = function (args /* array */, myparent, grandparent) {
+  obj.consoleaction = function (args /* array|string */, myparent, grandparent) {
+    if (typeof args === 'string') args = args.split(' ');
     if (Array.isArray(args) && args.length > 0) {
       if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
       const sub = String((args[0] || '')).toLowerCase();


### PR DESCRIPTION
## Summary
- Normalize console command arguments to handle string input
- Ensure both server and agent plugins respond to `ping`
- Bump plugin version to 0.0.62

## Testing
- `node - <<'NODE'
const vpn = require('./vpnviewer.js');
const plugin = vpn.vpnviewer({parent:{}, parent:{}});
console.log('array ping', plugin.consoleaction(['ping']));
console.log('string ping', plugin.consoleaction('vpnviewer ping'));
const agent = require('./modules_meshcore/vpnviewer.js');
console.log('agent array ping', agent.consoleaction(['ping']));
console.log('agent string ping', agent.consoleaction('vpnviewer ping'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68af2d9bc7108331b1e6a615dcbbe39e