### PR TITLE
Handle plugin prefix in vpnviewer console commands

### DIFF
--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -12,6 +12,7 @@
   function consoleaction(args /*array|string*/, parent, grandparent) {
     if (typeof args === 'string') args = args.split(' ');
     if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
+    if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
     if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
     var sub = String((args[0] || '')).toLowerCase();
 

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -39,6 +39,7 @@ module.exports.vpnviewer = function (parent) {
   obj.consoleaction = function (args /* array|string */, myparent, grandparent) {
     if (typeof args === 'string') args = args.split(' ');
     if (Array.isArray(args) && args.length > 0) {
+      if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
       if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
       const sub = String((args[0] || '')).toLowerCase();
       if (sub === 'ping') return 'vpnviewer server plugin: pong';


### PR DESCRIPTION
## Summary
- strip optional `plugin` prefix in server and agent console actions
- ensure `plugin vpnviewer ping` returns `pong`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f54db0c8331ae5ac531cd7dc937