### PR TITLE
Normalize console args for ping command

### DIFF
--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -9,8 +9,10 @@
   }
 
   // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
-  function consoleaction(args /*array*/, parent, grandparent) {
+  function consoleaction(args /*array|string*/, parent, grandparent) {
+    if (typeof args === 'string') args = args.split(' ');
     if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
+    if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
     if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
     var sub = String((args[0] || '')).toLowerCase();
 

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -36,8 +36,10 @@ module.exports.vpnviewer = function (parent) {
     QA("pluginVpnViewer", '<iframe id="vpnviewerFrame" style="width:100%;height:720px;border:0;overflow:auto" src="' + src + '"></iframe>');
   };
 
-  obj.consoleaction = function (args /* array */, myparent, grandparent) {
+  obj.consoleaction = function (args /* array|string */, myparent, grandparent) {
+    if (typeof args === 'string') args = args.split(' ');
     if (Array.isArray(args) && args.length > 0) {
+      if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
       if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
       const sub = String((args[0] || '')).toLowerCase();
       if (sub === 'ping') return 'vpnviewer server plugin: pong';


### PR DESCRIPTION
## Summary
- Handle console arguments passed as strings and ignore leading `plugin` prefix
- Ensure both server and agent modules respond to `plugin vpnviewer ping`

## Testing
- `node -e "const plugin=require('./vpnviewer.js').vpnviewer({parent:{}, parent:{}}); console.log(plugin.consoleaction(['vpnviewer','ping'])); console.log(plugin.consoleaction('plugin vpnviewer ping'));"`
- `node -e "const agent=require('./modules_meshcore/vpnviewer.js'); console.log(agent.consoleaction(['vpnviewer','ping'])); console.log(agent.consoleaction('plugin vpnviewer ping'));"`


------
https://chatgpt.com/codex/tasks/task_e_68af37b47f0083319f9fb3b5391d2e10