### PR TITLE
Handle object-style arguments in VPN viewer console commands

### DIFF
--- a/modules_meshcore/vpnviewer.js
+++ b/modules_meshcore/vpnviewer.js
@@ -9,11 +9,15 @@
   }
 
   // КОНСОЛЬНАЯ команда агента: "plugin vpnviewer <...>"
-  function consoleaction(args /*array|string*/, parent, grandparent) {
-    if (typeof args === 'string') args = args.split(' ');
-    if (!args || args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
-    if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
-    if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
+  function consoleaction(args /*array|string|object*/, parent, grandparent) {
+    // MeshCentral may pass args as string, array or {_:[]}; handle all cases.
+    if (typeof args === 'string') args = args.trim().split(/\s+/);
+    else if (Array.isArray(args)) args = args.slice();
+    else if (args && Array.isArray(args._)) args = args._.slice();
+    else args = [];
+    if (args.length === 0) return "usage: plugin vpnviewer [ping|read <path>|write <path> <text>]";
+    while (String(args[0]).toLowerCase() === 'plugin') args.shift();
+    while (String(args[0]).toLowerCase() === 'vpnviewer') args.shift();
     var sub = String((args[0] || '')).toLowerCase();
 
     if (sub === 'ping') return 'pong';

--- a/vpnviewer.js
+++ b/vpnviewer.js
@@ -36,11 +36,16 @@ module.exports.vpnviewer = function (parent) {
     QA("pluginVpnViewer", '<iframe id="vpnviewerFrame" style="width:100%;height:720px;border:0;overflow:auto" src="' + src + '"></iframe>');
   };
 
-  obj.consoleaction = function (args /* array|string */, myparent, grandparent) {
-    if (typeof args === 'string') args = args.split(' ');
-    if (Array.isArray(args) && args.length > 0) {
-      if (String(args[0]).toLowerCase() === 'plugin') args = args.slice(1);
-      if (String(args[0]).toLowerCase() === 'vpnviewer') args = args.slice(1);
+  obj.consoleaction = function (args /* array|string|object */, myparent, grandparent) {
+    // Accept different argument formats used by MeshCentral (string, array or {_:[]}).
+    if (typeof args === 'string') args = args.trim().split(/\s+/);
+    else if (Array.isArray(args)) args = args.slice();
+    else if (args && Array.isArray(args._)) args = args._.slice();
+    else args = [];
+
+    if (args.length > 0) {
+      while (String(args[0]).toLowerCase() === 'plugin') args.shift();
+      while (String(args[0]).toLowerCase() === 'vpnviewer') args.shift();
       const sub = String((args[0] || '')).toLowerCase();
       if (sub === 'ping') return 'vpnviewer server plugin: pong';
     }


### PR DESCRIPTION
## Summary
- normalize console command arguments to support objects, arrays, or strings in server and agent plugins
- ensure `plugin vpnviewer ping` works when MeshCentral supplies `{_:[]}` style arguments

## Testing
- `node -e "const p=require('./modules_meshcore/vpnviewer.js');console.log(p.consoleaction({_:['plugin','vpnviewer','ping']}));"`
- `node -e "const plugin=require('./vpnviewer.js').vpnviewer({parent:{}});console.log(plugin.consoleaction({_:['plugin','vpnviewer','ping']}));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af47c3c2e8833190475294e7ec5eb3